### PR TITLE
fix String2Byte

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -1,6 +1,9 @@
 package convert
 
-import "unsafe"
+import (
+	"reflect"
+	"unsafe"
+)
 
 // ByteToString converts a byte slice to string.
 func ByteToString(b []byte) string {
@@ -8,6 +11,8 @@ func ByteToString(b []byte) string {
 }
 
 // String2Byte converts a string to byte slice.
-func String2Byte(s string) []byte {
-	return *(*[]byte)(unsafe.Pointer(&s))
+func String2Byte(s string) (b []byte) {
+	b = *(*[]byte)(unsafe.Pointer(&s))
+	(*reflect.SliceHeader)(unsafe.Pointer(&b)).Cap = len(s)
+	return
 }

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -1,0 +1,23 @@
+package convert_test
+
+import (
+	"testing"
+
+	"github.com/go-playground/assert/v2"
+
+	"github.com/xiaojiaoyu100/lizard/convert"
+)
+
+func TestString2Byte(t *testing.T) {
+	s := "1234567890"
+	b := convert.String2Byte(s)
+	assert.Equal(t, len(b), len(s))
+	assert.Equal(t, cap(b), len(s))
+}
+
+func TestByteToString(t *testing.T) {
+	b := []byte("1234567890")
+	s := convert.ByteToString(b)
+	assert.Equal(t, len(b), len(s))
+	assert.Equal(t, cap(b), len(s))
+}


### PR DESCRIPTION
String2Byte返回的切片的cap没有赋值，md5Hash.Write时字符串超过64字节会出现panic。